### PR TITLE
Add a Rails concern to hold shared code

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,10 +3,16 @@
 /_yardoc/
 /coverage/
 /doc/
+/log/*.log
 /pkg/
 /spec/reports/
 /tmp/
+
+/spec/test_app/log/*.log
+/spec/test_app/storage/
+/spec/test_app/tmp/
+
 Gemfile.lock
 
 # rspec failure tracking
-.rspec_status
+/spec/examples.txt

--- a/lib/govuk_personalisation.rb
+++ b/lib/govuk_personalisation.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "govuk_personalisation/version"
+require "govuk_personalisation/account_concern"
 
 module GovukPersonalisation
   class Error < StandardError; end

--- a/lib/govuk_personalisation/account_concern.rb
+++ b/lib/govuk_personalisation/account_concern.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+require "active_support/concern"
+
+module GovukPersonalisation
+  module AccountConcern
+    extend ActiveSupport::Concern
+
+    ACCOUNT_SESSION_REQUEST_HEADER_NAME = "HTTP_GOVUK_ACCOUNT_SESSION"
+    ACCOUNT_SESSION_RESPONSE_HEADER_NAME = "GOVUK-Account-Session"
+    ACCOUNT_END_SESSION_RESPONSE_HEADER_NAME = "GOVUK-Account-End-Session"
+    ACCOUNT_SESSION_DEV_COOKIE_NAME = "govuk_account_session"
+
+    included do
+      before_action :fetch_account_session_header
+      attr_accessor :account_session_header
+    end
+
+    def logged_in?
+      account_session_header.present?
+    end
+
+    def fetch_account_session_header
+      @account_session_header =
+        if request.headers[ACCOUNT_SESSION_REQUEST_HEADER_NAME]
+          request.headers[ACCOUNT_SESSION_REQUEST_HEADER_NAME].presence
+        elsif Rails.env.development?
+          cookies[ACCOUNT_SESSION_DEV_COOKIE_NAME]
+        end
+    end
+
+    def set_account_session_header(govuk_account_session = nil)
+      @account_session_header = govuk_account_session if govuk_account_session
+      response.headers[ACCOUNT_SESSION_RESPONSE_HEADER_NAME] = @account_session_header
+      if Rails.env.development?
+        cookies[ACCOUNT_SESSION_DEV_COOKIE_NAME] = {
+          value: @account_session_header,
+          domain: "dev.gov.uk",
+        }
+      end
+    end
+
+    def logout!
+      response.headers[ACCOUNT_END_SESSION_RESPONSE_HEADER_NAME] = "1"
+      @account_session_header = nil
+      if Rails.env.development?
+        cookies[ACCOUNT_SESSION_DEV_COOKIE_NAME] = {
+          value: "",
+          domain: "dev.gov.uk",
+          expires: 1.second.ago,
+        }
+      end
+    end
+  end
+end

--- a/spec/account_concern_spec.rb
+++ b/spec/account_concern_spec.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+RSpec.describe "Sessions", type: :request do
+  describe "GET /show" do
+    let(:response_body) { JSON.parse(response.body) }
+
+    context "when the user is not logged in" do
+      let(:headers) { {} }
+
+      it "shows the logged_in status and the 'GOVUK-Account-Session' header value" do
+        get show_session_path, headers: headers
+
+        expect(response).to have_http_status(:ok)
+        expect(response_body).to eq("logged_in" => false, "account_session_header" => nil)
+      end
+    end
+
+    context "when the user is logged in" do
+      let(:account_session_header) { "foo" }
+      let(:headers) { { "GOVUK-Account-Session" => account_session_header } }
+
+      it "shows the logged_in status and the 'GOVUK-Account-Session' header value" do
+        get show_session_path, headers: headers
+
+        expect(response).to have_http_status(:ok)
+        expect(response_body).to eq("logged_in" => true, "account_session_header" => account_session_header)
+      end
+    end
+  end
+
+  describe "GET /update" do
+    it "sets the 'GOVUK-Account-Session' header" do
+      get update_session_path, params: { new_session_header: "bar" }
+
+      expect(response).to have_http_status(:no_content)
+      expect(response.headers["GOVUK-Account-Session"]).to eq("bar")
+      expect(response.body.blank?)
+    end
+  end
+
+  describe "GET /delete" do
+    it "sets the 'GOVUK-Account-End-Session' header" do
+      get delete_session_path
+
+      expect(response).to have_http_status(:no_content)
+      expect(response.headers["GOVUK-Account-End-Session"]).to eq("1")
+      expect(response.body.blank?)
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,15 +1,37 @@
 # frozen_string_literal: true
 
+ENV["RAILS_ENV"] = "test"
+ENV["RAILS_ROOT"] ||= "#{File.dirname(__FILE__)}../../../spec/test_app"
+
+require File.expand_path("../spec/test_app/config/environment.rb", __dir__)
+require "rspec/rails"
 require "govuk_personalisation"
 
 RSpec.configure do |config|
-  # Enable flags like --only-failures and --next-failure
-  config.example_status_persistence_file_path = ".rspec_status"
+  config.expect_with :rspec do |expectations|
+    expectations.syntax = :expect
+    expectations.include_chain_clauses_in_custom_matcher_descriptions = true
+  end
 
-  # Disable RSpec exposing methods globally on `Module` and `main`
+  config.mock_with :rspec do |mocks|
+    mocks.verify_partial_doubles = true
+  end
+
+  config.shared_context_metadata_behavior = :apply_to_host_groups
+
+  config.filter_run_when_matching :focus
+
+  config.example_status_persistence_file_path = "spec/examples.txt"
+
   config.disable_monkey_patching!
 
-  config.expect_with :rspec do |c|
-    c.syntax = :expect
+  if config.files_to_run.one?
+    config.default_formatter = "doc"
   end
+
+  config.profile_examples = 10
+
+  config.order = :random
+
+  Kernel.srand config.seed
 end

--- a/spec/test_app/README.md
+++ b/spec/test_app/README.md
@@ -1,0 +1,28 @@
+# README
+
+This is just a test app to test the gem's functionality. This way we don't need
+to rely on other apps to test the gem.
+The command run to create it was:
+
+```
+rails new spec/test_app \
+--skip-spring \
+--skip-listen \
+--skip-bootsnap \
+--skip-action-text \
+--skip-active-storage \
+--skip-action-cable \
+--skip-action-mailer \
+--skip-action-mailbox \
+--skip-test \
+--skip-system-test \
+--skip-active-job \
+--skip-active-record \
+--skip-javascript \
+--skip-gemfile \
+--skip-git
+```
+
+This approach was taken broadly following two guides:
+- https://dev.to/linqueta/how-to-test-your-gem-in-a-rails-application-2a0a
+- https://lokalise.com/blog/how-to-create-a-ruby-gem-testing-suite/#Creating_a_Rails_dummy_application

--- a/spec/test_app/app/assets/config/manifest.js
+++ b/spec/test_app/app/assets/config/manifest.js
@@ -1,0 +1,2 @@
+//= link_tree ../images
+//= link_directory ../stylesheets .css

--- a/spec/test_app/app/controllers/application_controller.rb
+++ b/spec/test_app/app/controllers/application_controller.rb
@@ -1,0 +1,2 @@
+class ApplicationController < ActionController::Base
+end

--- a/spec/test_app/app/controllers/sessions_controller.rb
+++ b/spec/test_app/app/controllers/sessions_controller.rb
@@ -1,0 +1,17 @@
+class SessionsController < ApplicationController
+  include GovukPersonalisation::AccountConcern
+
+  def show
+    render json: { logged_in: logged_in?, account_session_header: account_session_header }
+  end
+
+  def update
+    set_account_session_header params[:new_session_header]
+    head :no_content
+  end
+
+  def delete
+    logout!
+    head :no_content
+  end
+end

--- a/spec/test_app/config.ru
+++ b/spec/test_app/config.ru
@@ -1,0 +1,6 @@
+# This file is used by Rack-based servers to start the application.
+
+require_relative "config/environment"
+
+run Rails.application
+Rails.application.load_server

--- a/spec/test_app/config/application.rb
+++ b/spec/test_app/config/application.rb
@@ -1,0 +1,40 @@
+require_relative "boot"
+
+require "rails"
+# Pick the frameworks you want:
+require "active_model/railtie"
+# require "active_job/railtie"
+# require "active_record/railtie"
+# require "active_storage/engine"
+require "action_controller/railtie"
+# require "action_mailer/railtie"
+# require "action_mailbox/engine"
+# require "action_text/engine"
+require "action_view/railtie"
+# require "action_cable/engine"
+require "sprockets/railtie"
+# require "rails/test_unit/railtie"
+
+require "govuk_personalisation"
+
+# Require the gems listed in Gemfile, including any gems
+# you've limited to :test, :development, or :production.
+Bundler.require(*Rails.groups)
+
+module TestApp
+  class Application < Rails::Application
+    # Initialize configuration defaults for originally generated Rails version.
+    config.load_defaults 6.1
+
+    # Configuration for the application, engines, and railties goes here.
+    #
+    # These settings can be overridden in specific environments using the files
+    # in config/environments, which are processed later.
+    #
+    # config.time_zone = "Central Time (US & Canada)"
+    # config.eager_load_paths << Rails.root.join("extras")
+
+    # Don't generate system test files.
+    config.generators.system_tests = nil
+  end
+end

--- a/spec/test_app/config/boot.rb
+++ b/spec/test_app/config/boot.rb
@@ -1,0 +1,5 @@
+ENV["BUNDLE_GEMFILE"] ||= File.expand_path("../../../Gemfile", __dir__)
+
+require "bundler/setup" # Set up gems listed in the Gemfile.
+
+$LOAD_PATH.unshift File.expand_path("../../../lib", __dir__)

--- a/spec/test_app/config/environment.rb
+++ b/spec/test_app/config/environment.rb
@@ -1,0 +1,5 @@
+# Load the Rails application.
+require_relative "application"
+
+# Initialize the Rails application.
+Rails.application.initialize!

--- a/spec/test_app/config/routes.rb
+++ b/spec/test_app/config/routes.rb
@@ -1,0 +1,3 @@
+Rails.application.routes.draw do
+  # For details on the DSL available within this file, see https://guides.rubyonrails.org/routing.html
+end

--- a/spec/test_app/config/routes.rb
+++ b/spec/test_app/config/routes.rb
@@ -1,3 +1,5 @@
 Rails.application.routes.draw do
-  # For details on the DSL available within this file, see https://guides.rubyonrails.org/routing.html
+  get "/show", to: "sessions#show", as: :show_session
+  get "/update", to: "sessions#update", as: :update_session
+  get "/delete", to: "sessions#delete", as: :delete_session
 end


### PR DESCRIPTION
`GovukPersonalisation::AccountConcern` now holds accounts-related
functionality extracted from `frontend` and `finder-frontend` that these
two apps have in common.

Trello card: https://trello.com/c/40YbnkRp/783-add-a-rails-concern-to-govukpersonalisation