### PR TITLE
Always set `Vary: GOVUK-Account-Session` response header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+
+- Always set `Vary: GOVUK-Account-Session` response header ([#4](https://github.com/alphagov/govuk_personalisation/pull/4))
+
 ## [0.2.0]
 
 - Add AccountConcern to extract common account-related functionality ([#3](https://github.com/alphagov/govuk_personalisation/pull/3))

--- a/lib/govuk_personalisation/account_concern.rb
+++ b/lib/govuk_personalisation/account_concern.rb
@@ -13,6 +13,7 @@ module GovukPersonalisation
 
     included do
       before_action :fetch_account_session_header
+      before_action :set_account_vary_header
       attr_accessor :account_session_header
     end
 
@@ -27,6 +28,10 @@ module GovukPersonalisation
         elsif Rails.env.development?
           cookies[ACCOUNT_SESSION_DEV_COOKIE_NAME]
         end
+    end
+
+    def set_account_vary_header
+      response.headers["Vary"] = [response.headers["Vary"], ACCOUNT_SESSION_RESPONSE_HEADER_NAME].compact.join(", ")
     end
 
     def set_account_session_header(govuk_account_session = nil)

--- a/spec/account_concern_spec.rb
+++ b/spec/account_concern_spec.rb
@@ -12,6 +12,7 @@ RSpec.describe "Sessions", type: :request do
 
         expect(response).to have_http_status(:ok)
         expect(response_body).to eq("logged_in" => false, "account_session_header" => nil)
+        expect(response.headers["Vary"]).to eq("GOVUK-Account-Session")
       end
     end
 
@@ -24,6 +25,7 @@ RSpec.describe "Sessions", type: :request do
 
         expect(response).to have_http_status(:ok)
         expect(response_body).to eq("logged_in" => true, "account_session_header" => account_session_header)
+        expect(response.headers["Vary"]).to eq("GOVUK-Account-Session")
       end
     end
   end
@@ -34,6 +36,7 @@ RSpec.describe "Sessions", type: :request do
 
       expect(response).to have_http_status(:no_content)
       expect(response.headers["GOVUK-Account-Session"]).to eq("bar")
+      expect(response.headers["Vary"]).to eq("GOVUK-Account-Session")
       expect(response.body.blank?)
     end
   end
@@ -44,6 +47,7 @@ RSpec.describe "Sessions", type: :request do
 
       expect(response).to have_http_status(:no_content)
       expect(response.headers["GOVUK-Account-End-Session"]).to eq("1")
+      expect(response.headers["Vary"]).to eq("GOVUK-Account-Session")
       expect(response.body.blank?)
     end
   end


### PR DESCRIPTION
Right now we leave it up to individual apps to decide whether they
want to set

    Vary: GOVUK-Account-Session

or

    Cache-Control: no-store

This change means that apps won't need to worry about the `Vary`
header any more.

Setting just the `Vary` header is good when we want the user's browser
to be able to cache the page.  For example, the Transition Checker
results page can be cached, as the querystring contains all the data:
the only dynamic content on the page is the "these results are
different to the ones in your account" box, and it's no big deal if
that's missing due to the user seeing a cached copy.

Setting the `Cache-Control` header is good when we don't want to cache
the page at all, for example the `/sign-in` and `/sign-out` routes,
which manipulate the user's session.

But there's no downside to *always* setting the `Vary` header:

1. If the app only wants to set the `Vary` header, now they don't have
to (because the concern is doing it)

2. If the app wants to set the `Cache-Control` header, it can still do
that, and the `Vary` header becomes a no-op (because `Vary` restricts
when caching can happen, and the app is disabling caching)

There is no case in which we *need* `Cache-Control: no-store` to be
set and for `Vary: GOVUK-Account-Session` to be unset.  But even if
there were, the app could just use `skip_before_action` to achieve
that.