### PR TITLE
Add ability to set GOVUK-Account-Session

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.4.0
+
+- Add ability to set GOVUK-Account-Session ([#6](https://github.com/alphagov/govuk_personalisation/pull/6))
+
 # 0.3.0
 
 - Always set `Vary: GOVUK-Account-Session` response header ([#4](https://github.com/alphagov/govuk_personalisation/pull/4))

--- a/lib/govuk_personalisation.rb
+++ b/lib/govuk_personalisation.rb
@@ -2,6 +2,8 @@
 
 require "govuk_personalisation/version"
 require "govuk_personalisation/account_concern"
+require "govuk_personalisation/test_helpers/features"
+require "govuk_personalisation/test_helpers/requests"
 
 module GovukPersonalisation
   class Error < StandardError; end

--- a/lib/govuk_personalisation/test_helpers/features.rb
+++ b/lib/govuk_personalisation/test_helpers/features.rb
@@ -1,0 +1,9 @@
+module GovukPersonalisation
+  module TestHelpers
+    module Features
+      def mock_logged_in_session(value = "placeholder")
+        page.driver.header("GOVUK-Account-Session", value)
+      end
+    end
+  end
+end

--- a/lib/govuk_personalisation/test_helpers/requests.rb
+++ b/lib/govuk_personalisation/test_helpers/requests.rb
@@ -1,0 +1,9 @@
+module GovukPersonalisation
+  module TestHelpers
+    module Requests
+      def mock_logged_in_session(value = "placeholder")
+        request.headers["GOVUK-Account-Session"] = value
+      end
+    end
+  end
+end

--- a/lib/govuk_personalisation/version.rb
+++ b/lib/govuk_personalisation/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module GovukPersonalisation
-  VERSION = "0.3.0"
+  VERSION = "0.4.0"
 end


### PR DESCRIPTION
These modules can be included in other apps' test files. Those apps can
then just call `mock_logged_in_session` instead of setting the header
manually or define this helper method multiple times in different apps.

Trello card: https://trello.com/c/HpMFjE5Q/784-add-test-helpers-to-govukpersonalisation