### PR TITLE
Rename header name constants

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.5.0
+
+- Rename header name constants ([#7](https://github.com/alphagov/govuk_personalisation/pull/7))
+
 # 0.4.0
 
 - Add ability to set GOVUK-Account-Session ([#6](https://github.com/alphagov/govuk_personalisation/pull/6))

--- a/lib/govuk_personalisation/account_concern.rb
+++ b/lib/govuk_personalisation/account_concern.rb
@@ -6,9 +6,9 @@ module GovukPersonalisation
   module AccountConcern
     extend ActiveSupport::Concern
 
-    ACCOUNT_SESSION_REQUEST_HEADER_NAME = "HTTP_GOVUK_ACCOUNT_SESSION"
-    ACCOUNT_SESSION_RESPONSE_HEADER_NAME = "GOVUK-Account-Session"
-    ACCOUNT_END_SESSION_RESPONSE_HEADER_NAME = "GOVUK-Account-End-Session"
+    ACCOUNT_SESSION_INTERNAL_HEADER_NAME = "HTTP_GOVUK_ACCOUNT_SESSION"
+    ACCOUNT_SESSION_HEADER_NAME = "GOVUK-Account-Session"
+    ACCOUNT_END_SESSION_HEADER_NAME = "GOVUK-Account-End-Session"
     ACCOUNT_SESSION_DEV_COOKIE_NAME = "govuk_account_session"
 
     included do
@@ -23,20 +23,20 @@ module GovukPersonalisation
 
     def fetch_account_session_header
       @account_session_header =
-        if request.headers[ACCOUNT_SESSION_REQUEST_HEADER_NAME]
-          request.headers[ACCOUNT_SESSION_REQUEST_HEADER_NAME].presence
+        if request.headers[ACCOUNT_SESSION_INTERNAL_HEADER_NAME]
+          request.headers[ACCOUNT_SESSION_INTERNAL_HEADER_NAME].presence
         elsif Rails.env.development?
           cookies[ACCOUNT_SESSION_DEV_COOKIE_NAME]
         end
     end
 
     def set_account_vary_header
-      response.headers["Vary"] = [response.headers["Vary"], ACCOUNT_SESSION_RESPONSE_HEADER_NAME].compact.join(", ")
+      response.headers["Vary"] = [response.headers["Vary"], ACCOUNT_SESSION_HEADER_NAME].compact.join(", ")
     end
 
     def set_account_session_header(govuk_account_session = nil)
       @account_session_header = govuk_account_session if govuk_account_session
-      response.headers[ACCOUNT_SESSION_RESPONSE_HEADER_NAME] = @account_session_header
+      response.headers[ACCOUNT_SESSION_HEADER_NAME] = @account_session_header
       if Rails.env.development?
         cookies[ACCOUNT_SESSION_DEV_COOKIE_NAME] = {
           value: @account_session_header,
@@ -46,7 +46,7 @@ module GovukPersonalisation
     end
 
     def logout!
-      response.headers[ACCOUNT_END_SESSION_RESPONSE_HEADER_NAME] = "1"
+      response.headers[ACCOUNT_END_SESSION_HEADER_NAME] = "1"
       @account_session_header = nil
       if Rails.env.development?
         cookies[ACCOUNT_SESSION_DEV_COOKIE_NAME] = {

--- a/lib/govuk_personalisation/version.rb
+++ b/lib/govuk_personalisation/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module GovukPersonalisation
-  VERSION = "0.4.0"
+  VERSION = "0.5.0"
 end


### PR DESCRIPTION
This changes:

- `ACCOUNT_SESSION_REQUEST_HEADER_NAME` to
  `ACCOUNT_SESSION_INTERNAL_HEADER_NAME`

- `ACCOUNT_SESSION_RESPONSE_HEADER_NAME` to
  `ACCOUNT_SESSION_HEADER_NAME`

- `ACCOUNT_END_SESSION_RESPONSE_HEADER_NAME` to
  `ACCOUNT_END_SESSION_HEADER_NAME`

`"GOVUK-Account-Session"` is the externally available header's name both
for requests and responses. It only in gets changed by Rails in the
controller, where it becomes `"HTTP_GOVUK_ACCOUNT_SESSION"`.

So it makes sense to have `"GOVUK-Account-Session"` in a constant called
`ACCOUNT_SESSION_HEADER_NAME` and have `"HTTP_GOVUK_ACCOUNT_SESSION"` in
a constant called `ACCOUNT_SESSION_INTERNAL_HEADER_NAME`.

Similarly, this also removes the `RESPONSE` qualifier from the constant
that holds `"GOVUK-Account-End-Session"` so that it now becomes simply
`ACCOUNT_END_SESSION_HEADER_NAME`.