### PR TITLE
Add a module and methods for managing flash messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# unreleased
+
+- Add `GovukPersonalisation::Flash` and helper methods to the concern ([#9](https://github.com/alphagov/govuk_personalisation/pull/9))
+
 # 0.5.0
 
 - Rename header name constants ([#7](https://github.com/alphagov/govuk_personalisation/pull/7))

--- a/lib/govuk_personalisation.rb
+++ b/lib/govuk_personalisation.rb
@@ -2,6 +2,7 @@
 
 require "govuk_personalisation/version"
 require "govuk_personalisation/account_concern"
+require "govuk_personalisation/flash"
 require "govuk_personalisation/test_helpers/features"
 require "govuk_personalisation/test_helpers/requests"
 

--- a/lib/govuk_personalisation/account_concern.rb
+++ b/lib/govuk_personalisation/account_concern.rb
@@ -15,6 +15,7 @@ module GovukPersonalisation
       before_action :fetch_account_session_header
       before_action :set_account_vary_header
       attr_accessor :account_session_header
+      attr_reader :account_flash
     end
 
     def logged_in?
@@ -22,12 +23,18 @@ module GovukPersonalisation
     end
 
     def fetch_account_session_header
-      @account_session_header =
+      session_with_flash =
         if request.headers[ACCOUNT_SESSION_INTERNAL_HEADER_NAME]
           request.headers[ACCOUNT_SESSION_INTERNAL_HEADER_NAME].presence
         elsif Rails.env.development?
           cookies[ACCOUNT_SESSION_DEV_COOKIE_NAME]
         end
+
+      @account_session_header, flash = GovukPersonalisation::Flash.decode_session(session_with_flash)
+      @account_flash = (flash || []).index_with { |_| true }
+      @new_account_flash = {}
+
+      set_account_session_header unless @account_flash.empty?
     end
 
     def set_account_vary_header
@@ -36,10 +43,13 @@ module GovukPersonalisation
 
     def set_account_session_header(govuk_account_session = nil)
       @account_session_header = govuk_account_session if govuk_account_session
-      response.headers[ACCOUNT_SESSION_HEADER_NAME] = @account_session_header
+
+      session_with_flash = GovukPersonalisation::Flash.encode_session(@account_session_header, @new_account_flash.keys)
+
+      response.headers[ACCOUNT_SESSION_HEADER_NAME] = session_with_flash
       if Rails.env.development?
         cookies[ACCOUNT_SESSION_DEV_COOKIE_NAME] = {
-          value: @account_session_header,
+          value: session_with_flash,
           domain: "dev.gov.uk",
         }
       end
@@ -55,6 +65,27 @@ module GovukPersonalisation
           expires: 1.second.ago,
         }
       end
+    end
+
+    # Add a message to the flash to return to the user.  This does not
+    # change `account_flash`
+    #
+    # @param message [String] the message to add
+    #
+    # @return [true, false] whether the message is valid (and so has been added)
+    def account_flash_add(message)
+      return false unless GovukPersonalisation::Flash.valid_message? message
+
+      @new_account_flash[message] = true
+      set_account_session_header
+      true
+    end
+
+    # Copy all messages from the `account_flash` into the flash to
+    # return to the user.
+    def account_flash_keep
+      @new_account_flash = @account_flash.merge(@new_account_flash)
+      set_account_session_header
     end
   end
 end

--- a/lib/govuk_personalisation/flash.rb
+++ b/lib/govuk_personalisation/flash.rb
@@ -1,0 +1,50 @@
+# frozen_string-literal: true
+
+module GovukPersonalisation::Flash
+  SESSION_SEPARATOR = "$$"
+  MESSAGE_SEPARATOR = ","
+  MESSAGE_REGEX = /\A[a-zA-Z0-9._\-]+\z/.freeze
+
+  # Splits the session header into a session value (suitable for using
+  # in account-api calls) and flash messages.
+  #
+  # @param encoded_session [String] the value of the `GOVUK-Account-Session` header
+  #
+  # @return [Array(String, Array<String>), nil] the session value and the flash messages
+  def self.decode_session(encoded_session)
+    session_bits = encoded_session&.split(SESSION_SEPARATOR)
+    return if session_bits.blank?
+
+    if session_bits.length == 1
+      [session_bits[0], []]
+    else
+      [session_bits[0], session_bits[1].split(MESSAGE_SEPARATOR)]
+    end
+  end
+
+  # Encodes the session value and a list of flash messages into a
+  # session header which can be returned to the user.
+  #
+  # @param session [String]        the session value
+  # @param flash   [Array<String>] the flash messages, which must all be `valid_message?`
+  #
+  # @return [String] the encoded session header value
+  def self.encode_session(session, flash)
+    if flash.blank?
+      session
+    else
+      "#{session}#{SESSION_SEPARATOR}#{flash.join(MESSAGE_SEPARATOR)}"
+    end
+  end
+
+  # Check if a string is valid as a flash message.
+  #
+  # @param message [String, nil] the flash message
+  #
+  # @return [true, false] whether the message is valid or not.
+  def self.valid_message?(message)
+    return false if message.nil?
+
+    message.match? MESSAGE_REGEX
+  end
+end

--- a/lib/govuk_personalisation/test_helpers/features.rb
+++ b/lib/govuk_personalisation/test_helpers/features.rb
@@ -1,8 +1,8 @@
 module GovukPersonalisation
   module TestHelpers
     module Features
-      def mock_logged_in_session(value = "placeholder")
-        page.driver.header("GOVUK-Account-Session", value)
+      def mock_logged_in_session(value = "placeholder", flash = nil)
+        page.driver.header("GOVUK-Account-Session", GovukPersonalisation::Flash.encode_session(value, flash))
       end
     end
   end

--- a/lib/govuk_personalisation/test_helpers/requests.rb
+++ b/lib/govuk_personalisation/test_helpers/requests.rb
@@ -1,8 +1,8 @@
 module GovukPersonalisation
   module TestHelpers
     module Requests
-      def mock_logged_in_session(value = "placeholder")
-        request.headers["GOVUK-Account-Session"] = value
+      def mock_logged_in_session(value = "placeholder", flash = nil)
+        request.headers["GOVUK-Account-Session"] = GovukPersonalisation::Flash.encode_session(value, flash)
       end
     end
   end

--- a/spec/flash_spec.rb
+++ b/spec/flash_spec.rb
@@ -1,0 +1,86 @@
+# frozen_string_literal: true
+
+RSpec.describe GovukPersonalisation::Flash do
+  describe "#decode_session" do
+    let(:encoded_session) { "" }
+    subject(:decoded) { GovukPersonalisation::Flash.decode_session(encoded_session) }
+
+    it "returns nil" do
+      expect(decoded).to be_nil
+    end
+
+    context "the encoded session has one part" do
+      let(:encoded_session) { "session-id" }
+
+      it "returns the session and no flash messages" do
+        expect(decoded).to eq([encoded_session, []])
+      end
+    end
+
+    context "the encoded session has two parts" do
+      let(:encoded_session) { "#{session_id}$$#{flash.join(',')}" }
+      let(:session_id) { "session-id" }
+      let(:flash) { %w[foo bar baz] }
+
+      it "returns the session and the flash messages" do
+        expect(decoded).to eq([session_id, flash])
+      end
+
+      context "the flash part is empty" do
+        let(:flash) { [] }
+
+        it "returns the session and no flash messages" do
+          expect(decoded).to eq([session_id, []])
+        end
+      end
+    end
+  end
+
+  describe "#encode_session" do
+    let(:session) { "session-id" }
+    let(:flash) { %w[foo bar baz] }
+    subject(:encoded) { GovukPersonalisation::Flash.encode_session(session, flash) }
+
+    it "returns a two-part encoded session" do
+      expect(encoded).to eq("#{session}$$#{flash.join(',')}")
+    end
+
+    it "round-trips through #decode_session" do
+      expect(GovukPersonalisation::Flash.decode_session(encoded)).to eq([session, flash])
+    end
+
+    context "the flash is empty" do
+      let(:flash) { [] }
+
+      it "returns a one-part encoded session" do
+        expect(encoded).to eq(session)
+      end
+    end
+
+    context "the flash is nil" do
+      let(:flash) { nil }
+
+      it "returns a one-part encoded session" do
+        expect(encoded).to eq(session)
+      end
+    end
+  end
+
+  describe "#valid_message?" do
+    it "allows messages with alphanumeric characters, hyphens, underscores, and dots" do
+      expect(GovukPersonalisation::Flash.valid_message?("123-Message-With-_-And-.-In-It-456")).to be(true)
+    end
+
+    it "rejects messages containing '$$'" do
+      expect(GovukPersonalisation::Flash.valid_message?("message-with-$$-in-it")).to be(false)
+    end
+
+    it "rejects messages containing ','" do
+      expect(GovukPersonalisation::Flash.valid_message?("message-with-,-in-it")).to be(false)
+    end
+
+    it "rejects the nil message" do
+      expect(GovukPersonalisation::Flash.valid_message?(nil)).to be(false)
+    end
+  end
+end

--- a/spec/test_app/app/controllers/sessions_controller.rb
+++ b/spec/test_app/app/controllers/sessions_controller.rb
@@ -7,6 +7,8 @@ class SessionsController < ApplicationController
 
   def update
     set_account_session_header params[:new_session_header]
+    account_flash_keep if params[:keep_flash]
+    account_flash_add params[:add_to_flash]
     head :no_content
   end
 


### PR DESCRIPTION
The flash is a special piece of per-request state in the Rails
session, useful for showing success or failure messages, or other
confirmation-style notices.  Since flash messages are in the Rails
session, they cannot be used across microservices (without sharing the
session encryption key). But that is a feature we would like.

To allow sending flash messages for account purposes between
apps (e.g., a user signs up to email notifications for a page, then
gets redirected back to that page and it has a success banner), we
have decided to add them to the account session.

This commit adds a module for managing flash messages in the session,
and adds some helper methods to the `AccountConcern` to make it easy
to use.

See https://github.com/alphagov/account-api/blob/main/docs/api.md

---

[Trello card](https://trello.com/c/I0ulYzeX/946-implement-a-way-to-use-flash-messages-for-accounty-things)