### PR TITLE
Add support for CSRF tokens in the session, and add a `verify_account_authenticity_token` controller method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # unreleased
 
 - BREAKING: Move session encoding / decoding out of `GovukPersonalisation::Flash` and into `GovukPersonalisation::Session`
+- Add `verify_account_authenticity_token` method to protect against CSRF in OAuth journeys
 
 # 0.6.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# unreleased
+
+- BREAKING: Move session encoding / decoding out of `GovukPersonalisation::Flash` and into `GovukPersonalisation::Session`
+
 # 0.6.0
 
 - Add `GovukPersonalisation::Flash` and helper methods to the concern ([#9](https://github.com/alphagov/govuk_personalisation/pull/9))

--- a/lib/govuk_personalisation.rb
+++ b/lib/govuk_personalisation.rb
@@ -3,6 +3,7 @@
 require "govuk_personalisation/version"
 require "govuk_personalisation/controller_concern"
 require "govuk_personalisation/flash"
+require "govuk_personalisation/session"
 require "govuk_personalisation/test_helpers/features"
 require "govuk_personalisation/test_helpers/requests"
 

--- a/lib/govuk_personalisation/flash.rb
+++ b/lib/govuk_personalisation/flash.rb
@@ -1,40 +1,32 @@
 # frozen_string-literal: true
 
 module GovukPersonalisation::Flash
-  SESSION_SEPARATOR = "$$"
-  MESSAGE_SEPARATOR = ","
-  MESSAGE_REGEX = /\A[a-zA-Z0-9._\-]+\z/.freeze
+  SEPARATOR = ","
+  REGEX = /\A[a-zA-Z0-9._\-]+\z/.freeze
 
-  # Splits the session header into a session value (suitable for using
-  # in account-api calls) and flash messages.
+  # Splits an encoded string of flash messages into an object with
+  # keys being messages and values being `true`.
   #
-  # @param encoded_session [String] the value of the `GOVUK-Account-Session` header
+  # @param encoded_session [String] the encoded flash messages
   #
-  # @return [Array(String, Array<String>), nil] the session value and the flash messages
-  def self.decode_session(encoded_session)
-    session_bits = encoded_session&.split(SESSION_SEPARATOR)
-    return if session_bits.blank?
+  # @return [Hash<String, true>] the flash messages
+  def self.decode(encoded_flash)
+    messages = encoded_flash&.split(SEPARATOR) || []
+    return if messages.blank?
 
-    if session_bits.length == 1
-      [session_bits[0], []]
-    else
-      [session_bits[0], session_bits[1].split(MESSAGE_SEPARATOR)]
-    end
+    messages.index_with { |_| true }
   end
 
-  # Encodes the session value and a list of flash messages into a
-  # session header which can be returned to the user.
+  # Encodes a flash hash into a string which can be embedded into the
+  # session header.
   #
-  # @param session [String]        the session value
-  # @param flash   [Array<String>] the flash messages, which must all be `valid_message?`
+  # @param flash [Hash<String, true>] the flash messages, which must all be `valid_message?`
   #
-  # @return [String] the encoded session header value
-  def self.encode_session(session, flash)
-    if flash.blank?
-      session
-    else
-      "#{session}#{SESSION_SEPARATOR}#{flash.join(MESSAGE_SEPARATOR)}"
-    end
+  # @return [String] the flash value
+  def self.encode(flash)
+    return if flash.blank?
+
+    flash.keys.join(SEPARATOR)
   end
 
   # Check if a string is valid as a flash message.
@@ -45,6 +37,6 @@ module GovukPersonalisation::Flash
   def self.valid_message?(message)
     return false if message.nil?
 
-    message.match? MESSAGE_REGEX
+    message.match? REGEX
   end
 end

--- a/lib/govuk_personalisation/session.rb
+++ b/lib/govuk_personalisation/session.rb
@@ -1,0 +1,91 @@
+# frozen_string-literal: true
+
+module GovukPersonalisation::Session
+  SEPARATOR = "$$"
+  AUTHENTICITY_TOKEN_PREFIX = "csrf_"
+
+  # Splits the session header into components.
+  #
+  # After splitting by `FRAGMENT_SEPARATOR`, valid encodings are:
+  #
+  # - 0 components: `[                                 ]`
+  # - 1 component:  `[authenticity_token               ]`
+  # -               `[                    header       ]`
+  # - 2 components: `[authenticity_token, header       ]`
+  # -               `[                    header, flash]`
+  # - 3 components: `[authenticity_token, header, flash]`
+  #
+  # @param encoded_session [String] the value of the `GOVUK-Account-Session` header
+  #
+  # @return [Hash] the authenticity token, header for account-api, and
+  # flash messages; if there is a header for account-api, then the
+  # user is logged in.
+  def self.decode(encoded_session)
+    session_bits = encoded_session&.split(SEPARATOR)&.map(&:presence)
+    return {} if session_bits.blank?
+
+    has_authenticity_token, authenticity_token =
+      if session_bits[0].start_with? AUTHENTICITY_TOKEN_PREFIX
+        [true, session_bits[0].delete_prefix(AUTHENTICITY_TOKEN_PREFIX).presence]
+      else
+        [false, nil]
+      end
+
+    case session_bits.length
+    when 1
+      if has_authenticity_token
+        {
+          authenticity_token: authenticity_token,
+        }
+      else
+        {
+          header: session_bits[0],
+        }
+      end
+    when 2
+      if has_authenticity_token
+        {
+          authenticity_token: authenticity_token,
+          header: session_bits[1],
+        }
+      else
+        {
+          header: session_bits[0],
+          flash: GovukPersonalisation::Flash.decode(session_bits[1]),
+        }
+      end
+    else
+      {
+        authenticity_token: authenticity_token,
+        header: session_bits[1],
+        flash: GovukPersonalisation::Flash.decode(session_bits[2]),
+      }
+    end
+  end
+
+  # Encodes the session value and a list of flash messages into a
+  # session header which can be returned to the user.
+  #
+  # @param header             [String, nil]             the session value
+  # @param authenticity_token [String, nil]             an arbitrary authenticity token value
+  # @param flash              [Hash<String, true>, nil] the flash messages, which must all be `Flash.valid_message?`
+  #
+  # @return [String, nil] the encoded session header value
+  def self.encode(authenticity_token: nil, header: nil, flash: nil)
+    encoded_authenticity_token =
+      if authenticity_token.blank?
+        nil
+      else
+        "#{AUTHENTICITY_TOKEN_PREFIX}#{authenticity_token}"
+      end
+
+    encoded_flash =
+      if header.blank? || flash.blank?
+        nil
+      else
+        GovukPersonalisation::Flash.encode(flash)
+      end
+
+    [encoded_authenticity_token, header, encoded_flash].compact.join(SEPARATOR)
+  end
+end

--- a/spec/controller_concern_spec.rb
+++ b/spec/controller_concern_spec.rb
@@ -74,4 +74,21 @@ RSpec.describe "Sessions", type: :request do
       expect(response.body.blank?)
     end
   end
+
+  describe "GET /callback" do
+    it "throws an error if the authenticity token is missing" do
+      get callback_session_path
+      expect(response).to have_http_status(:bad_request)
+    end
+
+    it "throws an error if the authenticity token does not match" do
+      get callback_session_path, headers: { "GOVUK-Account-Session" => "csrf_token1" }, params: { account_authenticity_token: "token2" }
+      expect(response).to have_http_status(:bad_request)
+    end
+
+    it "does not throw an error if the tokens match" do
+      get callback_session_path, headers: { "GOVUK-Account-Session" => "csrf_token" }, params: { account_authenticity_token: "token" }
+      expect(response).to be_successful
+    end
+  end
 end

--- a/spec/flash_spec.rb
+++ b/spec/flash_spec.rb
@@ -1,67 +1,50 @@
 # frozen_string_literal: true
 
 RSpec.describe GovukPersonalisation::Flash do
-  describe "#decode_session" do
-    let(:encoded_session) { "" }
-    subject(:decoded) { GovukPersonalisation::Flash.decode_session(encoded_session) }
+  describe "#decode" do
+    let(:encoded) { "" }
+    subject(:decoded) { GovukPersonalisation::Flash.decode(encoded) }
 
     it "returns nil" do
       expect(decoded).to be_nil
     end
 
-    context "the encoded session has one part" do
-      let(:encoded_session) { "session-id" }
+    context "there are encoded messages" do
+      let(:encoded) { messages.join(",") }
+      let(:messages) { %w[foo bar baz] }
 
-      it "returns the session and no flash messages" do
-        expect(decoded).to eq([encoded_session, []])
-      end
-    end
-
-    context "the encoded session has two parts" do
-      let(:encoded_session) { "#{session_id}$$#{flash.join(',')}" }
-      let(:session_id) { "session-id" }
-      let(:flash) { %w[foo bar baz] }
-
-      it "returns the session and the flash messages" do
-        expect(decoded).to eq([session_id, flash])
-      end
-
-      context "the flash part is empty" do
-        let(:flash) { [] }
-
-        it "returns the session and no flash messages" do
-          expect(decoded).to eq([session_id, []])
-        end
+      it "returns a hash of messages" do
+        expect(decoded).to eq(messages.index_with { |_| true })
       end
     end
   end
 
-  describe "#encode_session" do
-    let(:session) { "session-id" }
-    let(:flash) { %w[foo bar baz] }
-    subject(:encoded) { GovukPersonalisation::Flash.encode_session(session, flash) }
+  describe "#encode" do
+    let(:messages) { %w[foo bar baz] }
+    let(:flash) { messages.index_with { |_| true } }
+    subject(:encoded) { GovukPersonalisation::Flash.encode(flash) }
 
-    it "returns a two-part encoded session" do
-      expect(encoded).to eq("#{session}$$#{flash.join(',')}")
+    it "encodes the messages" do
+      expect(encoded).to eq(messages.join(","))
     end
 
-    it "round-trips through #decode_session" do
-      expect(GovukPersonalisation::Flash.decode_session(encoded)).to eq([session, flash])
+    it "round-trips through #decode" do
+      expect(GovukPersonalisation::Flash.decode(encoded)).to eq(flash)
     end
 
     context "the flash is empty" do
       let(:flash) { [] }
 
-      it "returns a one-part encoded session" do
-        expect(encoded).to eq(session)
+      it "returns nil" do
+        expect(encoded).to eq(nil)
       end
     end
 
     context "the flash is nil" do
       let(:flash) { nil }
 
-      it "returns a one-part encoded session" do
-        expect(encoded).to eq(session)
+      it "returns nil" do
+        expect(encoded).to eq(nil)
       end
     end
   end

--- a/spec/session_spec.rb
+++ b/spec/session_spec.rb
@@ -1,0 +1,135 @@
+# frozen_string_literal: true
+
+RSpec.describe GovukPersonalisation::Session do
+  describe "#decode" do
+    let(:encoded) { [part1, part2, part3].compact.join("$$") }
+    let(:part1) { nil }
+    let(:part2) { nil }
+    let(:part3) { nil }
+    subject(:decoded) { GovukPersonalisation::Session.decode(encoded).compact }
+
+    it "returns an empty hash" do
+      expect(decoded).to eq({})
+    end
+
+    context "the encoded value has one component" do
+      let(:part1) { "foo" }
+
+      it "is decoded to a session header" do
+        expect(decoded).to eq({ header: encoded })
+      end
+
+      context "it starts with the AUTHENTICITY_TOKEN_PREFIX" do
+        let(:part1) { "csrf_#{authenticity_token}" }
+        let(:authenticity_token) { "foo" }
+
+        it "is decoded to an authenticity token" do
+          expect(decoded).to eq({ authenticity_token: authenticity_token })
+        end
+
+        context "there is nothing after the AUTHENTICITY_TOKEN_PREFIX" do
+          let(:authenticity_token) { "" }
+
+          it "returns an empty hash" do
+            expect(decoded).to eq({})
+          end
+        end
+      end
+    end
+
+    context "the encoded value has two components" do
+      let(:part1) { "foo" }
+      let(:part2) { "bar" }
+
+      it "is decoded to a session header and flash portion" do
+        expect(decoded).to eq({ header: part1, flash: to_flash(part2) })
+      end
+
+      context "the first part starts with the AUTHENTICITY_TOKEN_PREFIX" do
+        let(:part1) { "csrf_#{authenticity_token}" }
+        let(:authenticity_token) { "foo" }
+
+        it "is decoded to an authenticity token and a session header" do
+          expect(decoded).to eq({ authenticity_token: authenticity_token, header: part2 })
+        end
+
+        context "there is nothing after the AUTHENTICITY_TOKEN_PREFIX" do
+          let(:authenticity_token) { "" }
+
+          it "is decoded to a session header" do
+            expect(decoded).to eq({ header: part2 })
+          end
+        end
+      end
+    end
+
+    context "the encoded value has three components" do
+      let(:part1) { "foo" }
+      let(:part2) { "bar" }
+      let(:part3) { "baz" }
+
+      it "is decoded to a session header and a flash portion" do
+        expect(decoded).to eq({ header: part2, flash: to_flash(part3) })
+      end
+
+      context "the first part starts with the AUTHENTICITY_TOKEN_PREFIX" do
+        let(:part1) { "csrf_#{authenticity_token}" }
+        let(:authenticity_token) { "foo" }
+
+        it "is decoded to an authenticity token, a session header, and a flash portion" do
+          expect(decoded).to eq({ authenticity_token: authenticity_token, header: part2, flash: to_flash(part3) })
+        end
+
+        context "there is nothing after the AUTHENTICITY_TOKEN_PREFIX" do
+          let(:authenticity_token) { "" }
+
+          it "is decoded to a session header and a flash portion" do
+            expect(decoded).to eq({ header: part2, flash: to_flash(part3) })
+          end
+        end
+      end
+    end
+
+    def to_flash(str)
+      str.split(",").index_with { |_| true }
+    end
+  end
+
+  describe "#encode" do
+    subject(:encoded) { GovukPersonalisation::Session.encode(authenticity_token: authenticity_token, header: header, flash: flash) }
+    let(:decoded) { GovukPersonalisation::Session.decode(encoded).compact }
+    let(:expected_decoding) { { authenticity_token: authenticity_token, header: header, flash: flash }.compact }
+
+    let(:authenticity_token) { "foo" }
+    let(:header) { "bar" }
+    let(:flash) { { "baz" => true } }
+
+    it "round-trips through #decode" do
+      expect(decoded).to eq(expected_decoding)
+    end
+
+    context "the authenticity token is blank" do
+      let(:authenticity_token) { nil }
+
+      it "round-trips through #decode" do
+        expect(decoded).to eq(expected_decoding)
+      end
+    end
+
+    context "the header is blank" do
+      let(:header) { nil }
+
+      it "blanks the flash" do
+        expect(decoded).to eq(expected_decoding.merge(flash: nil).compact)
+      end
+    end
+
+    context "the flash is blank" do
+      let(:flash) { nil }
+
+      it "round-trips through #decode" do
+        expect(decoded).to eq(expected_decoding)
+      end
+    end
+  end
+end

--- a/spec/test_app/app/controllers/sessions_controller.rb
+++ b/spec/test_app/app/controllers/sessions_controller.rb
@@ -1,8 +1,16 @@
 class SessionsController < ApplicationController
   include GovukPersonalisation::ControllerConcern
 
+  before_action :verify_account_authenticity_token, only: %i[callback]
+
+  rescue_from GovukPersonalisation::ControllerConcern::InvalidAccountAuthenticityToken, with: -> { head :bad_request }
+
   def show
     render json: { logged_in: logged_in?, account_session_header: account_session_header }
+  end
+
+  def callback
+    head :no_content
   end
 
   def update

--- a/spec/test_app/config/routes.rb
+++ b/spec/test_app/config/routes.rb
@@ -1,5 +1,6 @@
 Rails.application.routes.draw do
   get "/show", to: "sessions#show", as: :show_session
+  get "/callback", to: "sessions#callback", as: :callback_session
   get "/update", to: "sessions#update", as: :update_session
   get "/delete", to: "sessions#delete", as: :delete_session
 end


### PR DESCRIPTION
We're adding a third, optional, component to the session: a CSRF
token.  I've called it an "authenticity token" to match the
terminology Rails uses for its CSRF tokens.

As with the flash, it'll be separated from the session ID by a "$$".
After splitting on "$$", valid session header will be one of:

```
- 0 components: `[                         ]`
- 1 component:  `[csrf_token               ]`
-               `[            header       ]`
- 2 components: `[csrf_token, header       ]`
-               `[            header, flash]`
- 3 components: `[csrf_token, header, flash]`
```

To disambiguate a CSRF token from a header, CSRF tokens start with
"csrf_".

The use-case for this feature will be:

1. Authenticating a user: the OAuth state will be saved as the CSRF
token in the session, and checked in the callback.

2. Passing a user from the auth callback to another part of GOV.UK:
the state will be passed as a query param and checked in the app.

(1) is so that an attacker can't just link a user to
www.gov.uk/account/sign-in/callback?code=...&state=... to log them in
to an account (or, trick them into authenticating and sending the
attacker such a URL).

(2) is so that an attacker can't just link a user to
www.gov.uk/make-a-new-email-subscription?topic=... (or whatever) to
create a new email subscription if they're already logged in.
Normally we'd protect such pages by making them POST endpoints and
using the default Rails CSRF protection but, since we need to be able
to handle GETs, we need to implement our own thing.   We have such
methods because a common pattern with OAuth is:

1. Try to do a thing
2. Fail, because the user's session is missing / invalid
3. Redirect them to authenticate
4. Redirect them back to the original page
5. Do the thing

So we need the page which does the thing to be available for GET
requests, which means we need CSRF protection for it.

---

[Trello card](https://trello.com/c/79pWZ00F/951-implement-csrf-protection-for-account-oauth-journeys)