### PR TITLE
Change sign in path to `/sign-in/redirect`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# unreleased
+
+- Change sign in path to `/sign-in/redirect` ([#17](https://github.com/alphagov/govuk_personalisation/pull/17))
+
 # 0.7.0
 
 - Add `GovukPersonalisation::Urls` module ([#14](https://github.com/alphagov/govuk_personalisation/pull/14) [#16](https://github.com/alphagov/govuk_personalisation/pull/16))

--- a/lib/govuk_personalisation/urls.rb
+++ b/lib/govuk_personalisation/urls.rb
@@ -5,7 +5,7 @@ module GovukPersonalisation::Urls
   #
   # @return [String] the URL
   def self.sign_in
-    find_govuk_url(var: "SIGN_IN", application: "frontend", path: "/sign-in")
+    find_govuk_url(var: "SIGN_IN", application: "frontend", path: "/sign-in/redirect")
   end
 
   # Find the GOV.UK URL for the "sign out" page


### PR DESCRIPTION
Depends on https://github.com/alphagov/account-api/pull/218 & https://github.com/alphagov/frontend/pull/2951

---

We have changed the route in account-api / frontend.

---

[Trello card](https://trello.com/c/P8JbW0T8/1048-move-oauth-sign-in-start-page-from-sign-in-to-sign-in-redirect)