### PR TITLE
Bump to version 0.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
-# Unreleased
-- Add `redirect_with_analytics` helper, attaches _ga and cookie_consent values from existing params to redirects.
-- Add `GovukPersonalisation::Redirect` and `.build_url` helper to construct valid URLs with additional parameters
+# 0.9.0
+- Add `redirect_with_analytics` helper, attaches _ga and cookie_consent values from existing params to redirects. ([#19](https://github.com/alphagov/govuk_personalisation/pull/19))
+- Add `GovukPersonalisation::Redirect` and `.build_url` helper to construct valid URLs with additional parameters. ([#19](https://github.com/alphagov/govuk_personalisation/pull/19))
 
 # 0.8.0
 

--- a/lib/govuk_personalisation/version.rb
+++ b/lib/govuk_personalisation/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module GovukPersonalisation
-  VERSION = "0.8.0"
+  VERSION = "0.9.0"
 end


### PR DESCRIPTION
To include the changes from https://github.com/alphagov/govuk_personalisation/pull/19

https://trello.com/c/6jDzptnV/1043-pass-cookie-consent-flag-to-di