### PR TITLE
Add url_with_analytics method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# Unreleased
+- Add `url_with_analytics` helper to allow apps to access the URL used for `redirect_with_analytics` ([#22](https://github.com/alphagov/govuk_personalisation/pull/22))
+
 # 0.9.0
 - Add `redirect_with_analytics` helper, attaches _ga and cookie_consent values from existing params to redirects. ([#19](https://github.com/alphagov/govuk_personalisation/pull/19))
 - Add `GovukPersonalisation::Redirect` and `.build_url` helper to construct valid URLs with additional parameters. ([#19](https://github.com/alphagov/govuk_personalisation/pull/19))

--- a/lib/govuk_personalisation/controller_concern.rb
+++ b/lib/govuk_personalisation/controller_concern.rb
@@ -131,7 +131,15 @@ module GovukPersonalisation
     #
     # @param url [String] The URL to redirect to
     def redirect_with_analytics(url)
-      redirect_to GovukPersonalisation::Redirect.build_url(url, params.permit(:_ga, :cookie_consent).to_h)
+      redirect_to url_with_analytics(url)
+    end
+
+    # Build a URL adding parameters necessary for cross-domain analytics
+    # and cookie consent
+    #
+    # @param url [String] The URL
+    def url_with_analytics(url)
+      GovukPersonalisation::Redirect.build_url(url, params.permit(:_ga, :cookie_consent).to_h)
     end
   end
 end


### PR DESCRIPTION
And refactor `redirect_with_analytics` to use it. In some cases we want
to use this URL in the apps (eg. on an href in an `<a>` tag, so expose
a method in the gem.