### PR TITLE
Make session-change events uncacheable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# unreleased
+
+- Make session-change events uncacheable ([#24](https://github.com/alphagov/govuk_personalisation/pull/24))
+
 # 0.10.0
 - Add `url_with_analytics` helper to allow apps to access the URL used for `redirect_with_analytics` ([#22](https://github.com/alphagov/govuk_personalisation/pull/22))
 

--- a/lib/govuk_personalisation/controller_concern.rb
+++ b/lib/govuk_personalisation/controller_concern.rb
@@ -83,6 +83,8 @@ module GovukPersonalisation
       session_with_flash = GovukPersonalisation::Flash.encode_session(@account_session_header, @new_account_flash.keys)
 
       response.headers[ACCOUNT_SESSION_HEADER_NAME] = session_with_flash
+      response.headers["Cache-Control"] = "no-store"
+
       if Rails.env.development?
         cookies[ACCOUNT_SESSION_DEV_COOKIE_NAME] = {
           value: session_with_flash,
@@ -95,7 +97,10 @@ module GovukPersonalisation
     # header.
     def logout!
       response.headers[ACCOUNT_END_SESSION_HEADER_NAME] = "1"
+      response.headers["Cache-Control"] = "no-store"
+
       @account_session_header = nil
+
       if Rails.env.development?
         cookies[ACCOUNT_SESSION_DEV_COOKIE_NAME] = {
           value: "",

--- a/spec/controller_concern/sessions_spec.rb
+++ b/spec/controller_concern/sessions_spec.rb
@@ -14,6 +14,11 @@ RSpec.describe "Sessions", type: :request do
         expect(response_body).to eq("logged_in" => false, "account_session_header" => nil)
         expect(response.headers["Vary"]).to eq("GOVUK-Account-Session")
       end
+
+      it "does not make the response uncacheable" do
+        get show_session_path, headers: headers
+        expect(response.headers["Cache-Control"]).not_to eq("no-store")
+      end
     end
 
     context "when the user is logged in" do
@@ -28,6 +33,11 @@ RSpec.describe "Sessions", type: :request do
         expect(response.headers["Vary"]).to eq("GOVUK-Account-Session")
       end
 
+      it "does not make the response uncacheable" do
+        get show_session_path, headers: headers
+        expect(response.headers["Cache-Control"]).not_to eq("no-store")
+      end
+
       context "when there is a flash in the user's session" do
         let(:account_session_header) { "#{session_id}$$flash" }
         let(:session_id) { "foo" }
@@ -35,6 +45,11 @@ RSpec.describe "Sessions", type: :request do
         it "returns an empty flash in the response" do
           get show_session_path, headers: headers
           expect(response.headers["GOVUK-Account-Session"]).to eq(session_id)
+        end
+
+        it "makes the response uncacheable" do
+          get show_session_path, headers: headers
+          expect(response.headers["Cache-Control"]).to eq("no-store")
         end
       end
     end
@@ -48,6 +63,11 @@ RSpec.describe "Sessions", type: :request do
       expect(response.headers["GOVUK-Account-Session"]).to eq("bar")
       expect(response.headers["Vary"]).to eq("GOVUK-Account-Session")
       expect(response.body.blank?)
+    end
+
+    it "makes the response uncacheable" do
+      get update_session_path, params: { new_session_header: "bar" }
+      expect(response.headers["Cache-Control"]).to eq("no-store")
     end
 
     it "preserves the flash" do
@@ -72,6 +92,11 @@ RSpec.describe "Sessions", type: :request do
       expect(response.headers["GOVUK-Account-End-Session"]).to eq("1")
       expect(response.headers["Vary"]).to eq("GOVUK-Account-Session")
       expect(response.body.blank?)
+    end
+
+    it "makes the response uncacheable" do
+      get delete_session_path
+      expect(response.headers["Cache-Control"]).to eq("no-store")
     end
   end
 end


### PR DESCRIPTION
We already do this in our Fastly configuration, but that isn't a full
solution, as our own Varnish may cache such a response.

This hasn't been an issue so far, as all session-changing pages have
been explicitly uncacheable (or had `Vary: GOVUK-Account-Session`);
but it is a problem for pages with flash messages, as the controller
concern will strip the flash from the cookie, and so if that response
gets cached, we'll switch subsequent users who visit the same
page (perhaps with the same flash message, if `Vary:
GOVUK-Account-Session-Flash` is set) to that first user's account.