### PR TITLE
Change the sign in URL to /account

### DIFF
--- a/lib/govuk_personalisation/urls.rb
+++ b/lib/govuk_personalisation/urls.rb
@@ -5,7 +5,7 @@ module GovukPersonalisation::Urls
   #
   # @return [String] the URL
   def self.sign_in
-    find_govuk_url(var: "SIGN_IN", application: "frontend", path: "/sign-in/redirect")
+    find_govuk_url(var: "SIGN_IN", application: "frontend", path: "/account")
   end
 
   # Find the GOV.UK URL for the "sign out" page


### PR DESCRIPTION
We're retiring /sign-in/redirect in favour of this.

---

[Trello card](https://trello.com/c/1tMOYsbk/1218-change-sign-in-link-to-use-di-domain)