### PR TITLE
Add support for Rails 7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# unreleased
+
+- Add support for Rails 7 ([#33](https://github.com/alphagov/govuk_personalisation/pull/33))
+
 # 0.11.1
 
 - Change sign in path to `/account` ([#28](https://github.com/alphagov/govuk_personalisation/pull/28))

--- a/govuk_personalisation.gemspec
+++ b/govuk_personalisation.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = %w[lib]
 
   spec.add_dependency "plek", ">= 1.9.0"
-  spec.add_dependency "rails", "~> 6"
+  spec.add_dependency "rails", ">= 6", "< 8"
 
   spec.add_development_dependency "bundler"
   spec.add_development_dependency "climate_control"

--- a/lib/govuk_personalisation/controller_concern.rb
+++ b/lib/govuk_personalisation/controller_concern.rb
@@ -135,8 +135,8 @@ module GovukPersonalisation
     # and cookie consent
     #
     # @param url [String] The URL to redirect to
-    def redirect_with_analytics(url)
-      redirect_to url_with_analytics(url)
+    def redirect_with_analytics(url, allow_other_host: true)
+      redirect_to(url_with_analytics(url), allow_other_host: allow_other_host)
     end
 
     # Build a URL adding parameters necessary for cross-domain analytics

--- a/spec/test_app/config/application.rb
+++ b/spec/test_app/config/application.rb
@@ -12,7 +12,7 @@ require "action_controller/railtie"
 # require "action_text/engine"
 require "action_view/railtie"
 # require "action_cable/engine"
-require "sprockets/railtie"
+# require "sprockets/railtie"
 # require "rails/test_unit/railtie"
 
 require "govuk_personalisation"
@@ -23,8 +23,12 @@ Bundler.require(*Rails.groups)
 
 module TestApp
   class Application < Rails::Application
-    # Initialize configuration defaults for originally generated Rails version.
-    config.load_defaults 6.1
+    case Rails::VERSION::MAJOR
+    when 7
+      config.load_defaults 7.0
+    when 6
+      config.load_defaults 6.0
+    end
 
     # Configuration for the application, engines, and railties goes here.
     #


### PR DESCRIPTION
Since we're now claiming to support two major versions of rails, we should test against both.  Fortunately, our govuk-jenkinslib gives us this by accident: we test gems against both ruby 2.6 and 2.7, and rails 7 does not support ruby 2.6.

However, since ruby 2.6 is end-of-life next month, we may want to remove it from govuk-jenkinslib and drop rails 6 compatibility in this gem after we've upgraded all the apps which use it to rails 7.

---

[Trello card](https://trello.com/c/TR4wziBW/1240-update-apps-to-rails-7)