### PR TITLE
Set default account home page to Digital Identity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Unreleased
+
+- Set account home to Digital Identity URI ([#36](https://github.com/alphagov/govuk_personalisation/pull/36))
+
 # 0.11.2
 
 - Add support for Rails 7 ([#33](https://github.com/alphagov/govuk_personalisation/pull/33))

--- a/lib/govuk_personalisation/urls.rb
+++ b/lib/govuk_personalisation/urls.rb
@@ -15,11 +15,11 @@ module GovukPersonalisation::Urls
     find_govuk_url(var: "SIGN_OUT", application: "frontend", path: "/sign-out")
   end
 
-  # Find the GOV.UK URL for the "your account" page
+  # Find the external URL for the "your account" page
   #
   # @return [String] the URL
   def self.your_account
-    find_govuk_url(var: "YOUR_ACCOUNT", application: "frontend", path: "/account/home")
+    find_external_url(var: "YOUR_ACCOUNT", url: "https://#{digital_identity_domain}")
   end
 
   # Find the external URL for the "manage" page


### PR DESCRIPTION
We are in the process of moving the account home page from
`www.gov.uk/account/home` (served by Frontend) to an app on the DI side,
which is part of separating out central account features from the
`www.gov.uk` relying party.

To do so, we'll update `govuk_personalisation` with the new link and
change the controller in Frontend that currently serves that page to
redirect on to the new one. This allows us to do an environment aware
redirect.

Apps currently have the `YOUR_ACCOUNT` environment variables set (see
https://github.com/alphagov/govuk-puppet/pull/11728), which override
the URI generated by this library. This means this change is safe to be
released and it won't affect where apps send users yet.

Once we're ready, we'll make another change in Puppet and set the
environment variables to point to the DI URI.