### PR TITLE
Add link to 'manage emails' page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Unreleased
 
 - Set account home to Digital Identity URI ([#36](https://github.com/alphagov/govuk_personalisation/pull/36))
+- Add `GovukPersonalisation::Urls.manage_email` link ([#38](https://github.com/alphagov/govuk_personalisation/pull/38))
+
 
 # 0.11.2
 

--- a/lib/govuk_personalisation/urls.rb
+++ b/lib/govuk_personalisation/urls.rb
@@ -15,6 +15,13 @@ module GovukPersonalisation::Urls
     find_govuk_url(var: "SIGN_OUT", application: "frontend", path: "/sign-out")
   end
 
+  # Find the GOV.UK URL for the "email manager" page
+  #
+  # @return [String] the URL
+  def self.manage_email
+    find_govuk_url(var: "SIGN_OUT", application: "email-alert-frontend", path: "/email/manage")
+  end
+
   # Find the external URL for the "your account" page
   #
   # @return [String] the URL


### PR DESCRIPTION
When we move the account home page out of Frontend, some journeys will
need to redirect users to the manage emails page as the default GOV.UK
page, rather than the home page.

In order to do this, Frontend needs to know how what URL to send people
to.

Don't merge before #36 