### PR TITLE
Add github actions config and remove jenkins config

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,36 @@
+on: [push, pull_request]
+
+jobs:
+  # This matrix job runs the test suite against multiple Ruby versions
+  test_matrix:
+    strategy:
+      fail-fast: false
+      matrix:
+        # Due to https://github.com/actions/runner/issues/849, we have to use quotes for '3.0'
+        ruby: [ 2.7, '3.0', 3.1 ]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby }}
+          bundler-cache: true
+      - run: bundle exec rake
+
+  # Branch protection rules cannot directly depend on status checks from matrix jobs.
+  # So instead we define `test` as a dummy job which only runs after the preceding `test_matrix` checks have passed.
+  # Solution inspired by: https://github.community/t/status-check-for-a-matrix-jobs/127354/3
+  test:
+    needs: test_matrix
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "All matrix tests have passed 🚀"
+
+  publish:
+    needs: test
+    if: ${{ github.ref == 'refs/heads/main' }}
+    permissions:
+      contents: write
+    uses: alphagov/govuk-infrastructure/.github/workflows/publish-rubygem.yaml@main
+    secrets:
+      GEM_HOST_API_KEY: ${{ secrets.ALPHAGOV_RUBYGEMS_API_KEY }}

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,3 +1,4 @@
 inherit_gem:
   rubocop-govuk:
     - config/default.yml
+    - config/rspec.yml

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,7 +1,0 @@
-#!/usr/bin/env groovy
-
-library("govuk")
-
-node {
-  govuk.buildProject()
-}

--- a/govuk_personalisation.gemspec
+++ b/govuk_personalisation.gemspec
@@ -33,5 +33,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "pry-byebug"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "rspec-rails"
-  spec.add_development_dependency "rubocop-govuk"
+  spec.add_development_dependency "rubocop-govuk", "4.7.0"
 end

--- a/spec/controller_concern/sessions_spec.rb
+++ b/spec/controller_concern/sessions_spec.rb
@@ -62,7 +62,7 @@ RSpec.describe "Sessions", type: :request do
       expect(response).to have_http_status(:no_content)
       expect(response.headers["GOVUK-Account-Session"]).to eq("bar")
       expect(response.headers["Vary"]).to eq("GOVUK-Account-Session")
-      expect(response.body.blank?)
+      expect(response.body).to be_blank
     end
 
     it "makes the response uncacheable" do
@@ -91,7 +91,7 @@ RSpec.describe "Sessions", type: :request do
       expect(response).to have_http_status(:no_content)
       expect(response.headers["GOVUK-Account-End-Session"]).to eq("1")
       expect(response.headers["Vary"]).to eq("GOVUK-Account-Session")
-      expect(response.body.blank?)
+      expect(response.body).to be_blank
     end
 
     it "makes the response uncacheable" do

--- a/spec/govuk_personalisation/flash_spec.rb
+++ b/spec/govuk_personalisation/flash_spec.rb
@@ -2,14 +2,15 @@
 
 RSpec.describe GovukPersonalisation::Flash do
   describe "#decode_session" do
+    subject(:decoded) { described_class.decode_session(encoded_session) }
+
     let(:encoded_session) { "" }
-    subject(:decoded) { GovukPersonalisation::Flash.decode_session(encoded_session) }
 
     it "returns nil" do
       expect(decoded).to be_nil
     end
 
-    context "the encoded session has one part" do
+    context "when the encoded session has one part" do
       let(:encoded_session) { "session-id" }
 
       it "returns the session and no flash messages" do
@@ -17,7 +18,7 @@ RSpec.describe GovukPersonalisation::Flash do
       end
     end
 
-    context "the encoded session has two parts" do
+    context "when the encoded session has two parts" do
       let(:encoded_session) { "#{session_id}$$#{flash.join(',')}" }
       let(:session_id) { "session-id" }
       let(:flash) { %w[foo bar baz] }
@@ -26,7 +27,7 @@ RSpec.describe GovukPersonalisation::Flash do
         expect(decoded).to eq([session_id, flash])
       end
 
-      context "the flash part is empty" do
+      context "when the flash part is empty" do
         let(:flash) { [] }
 
         it "returns the session and no flash messages" do
@@ -37,19 +38,20 @@ RSpec.describe GovukPersonalisation::Flash do
   end
 
   describe "#encode_session" do
+    subject(:encoded) { described_class.encode_session(session, flash) }
+
     let(:session) { "session-id" }
     let(:flash) { %w[foo bar baz] }
-    subject(:encoded) { GovukPersonalisation::Flash.encode_session(session, flash) }
 
     it "returns a two-part encoded session" do
       expect(encoded).to eq("#{session}$$#{flash.join(',')}")
     end
 
     it "round-trips through #decode_session" do
-      expect(GovukPersonalisation::Flash.decode_session(encoded)).to eq([session, flash])
+      expect(described_class.decode_session(encoded)).to eq([session, flash])
     end
 
-    context "the flash is empty" do
+    context "when the flash is empty" do
       let(:flash) { [] }
 
       it "returns a one-part encoded session" do
@@ -57,7 +59,7 @@ RSpec.describe GovukPersonalisation::Flash do
       end
     end
 
-    context "the flash is nil" do
+    context "when the flash is nil" do
       let(:flash) { nil }
 
       it "returns a one-part encoded session" do
@@ -68,19 +70,19 @@ RSpec.describe GovukPersonalisation::Flash do
 
   describe "#valid_message?" do
     it "allows messages with alphanumeric characters, hyphens, underscores, and dots" do
-      expect(GovukPersonalisation::Flash.valid_message?("123-Message-With-_-And-.-In-It-456")).to be(true)
+      expect(described_class.valid_message?("123-Message-With-_-And-.-In-It-456")).to be(true)
     end
 
     it "rejects messages containing '$$'" do
-      expect(GovukPersonalisation::Flash.valid_message?("message-with-$$-in-it")).to be(false)
+      expect(described_class.valid_message?("message-with-$$-in-it")).to be(false)
     end
 
     it "rejects messages containing ','" do
-      expect(GovukPersonalisation::Flash.valid_message?("message-with-,-in-it")).to be(false)
+      expect(described_class.valid_message?("message-with-,-in-it")).to be(false)
     end
 
     it "rejects the nil message" do
-      expect(GovukPersonalisation::Flash.valid_message?(nil)).to be(false)
+      expect(described_class.valid_message?(nil)).to be(false)
     end
   end
 end

--- a/spec/govuk_personalisation/redirect_spec.rb
+++ b/spec/govuk_personalisation/redirect_spec.rb
@@ -1,8 +1,9 @@
 RSpec.describe GovukPersonalisation::Redirect do
   describe "#build_url" do
+    subject(:url) { described_class.build_url(base_url, additional_params) }
+
     let(:base_url) { "https://test.gov.uk/thing?param&param-with-key=test" }
     let(:additional_params) { {} }
-    subject(:url) { GovukPersonalisation::Redirect.build_url(base_url, additional_params) }
 
     context "with a single additional parameter" do
       let(:additional_params) { { _ga: "abc123" } }
@@ -14,6 +15,7 @@ RSpec.describe GovukPersonalisation::Redirect do
 
     context "with multiple additional parameters" do
       let(:additional_params) { { _ga: "abc123", cookie_consent: "accept" } }
+
       it "adds the parameters and maintains the existing base_url" do
         expect(url).to eq("#{base_url}&_ga=abc123&cookie_consent=accept")
       end
@@ -22,13 +24,14 @@ RSpec.describe GovukPersonalisation::Redirect do
     context "with duplicate parameters in the base_url" do
       let(:base_url) { "https://test.gov.uk/thing?param=123&param=abc" }
       let(:additional_params) { { _ga: "abc123", cookie_consent: "accept" } }
+
       it "adds the parameters and maintains the existing base_url" do
         expect(url).to eq("#{base_url}&_ga=abc123&cookie_consent=accept")
       end
     end
 
     it "redirects to the base url if no parameters are provided" do
-      url = GovukPersonalisation::Redirect.build_url(base_url)
+      url = described_class.build_url(base_url)
       expect(url).to eq(base_url.to_s)
     end
   end

--- a/spec/govuk_personalisation/urls_spec.rb
+++ b/spec/govuk_personalisation/urls_spec.rb
@@ -2,7 +2,7 @@ require "climate_control"
 
 RSpec.describe GovukPersonalisation::Urls do
   describe "#find_govuk_url" do
-    subject(:url) { GovukPersonalisation::Urls.find_govuk_url(var: var, application: application, path: path) }
+    subject(:url) { described_class.find_govuk_url(var: var, application: application, path: path) }
 
     let(:var) { "TEST" }
     let(:application) { "test-frontend-app" }
@@ -38,7 +38,7 @@ RSpec.describe GovukPersonalisation::Urls do
   end
 
   describe "#find_external_url" do
-    subject(:url) { GovukPersonalisation::Urls.find_external_url(var: var, url: given_url) }
+    subject(:url) { described_class.find_external_url(var: var, url: given_url) }
 
     let(:var) { "TEST" }
     let(:given_url) { "https://www.example.com" }


### PR DESCRIPTION
As per [RFC-123](https://github.com/alphagov/govuk-rfcs/blob/main/rfc-123-github-actions-ci.md) we're moving away from Jenkins for testing and publishing our gems via github actions.

https://trello.com/c/QrxjshEm/270-move-ruby-gems-from-jenkins-to-github-actions