### PR TITLE
Update URL to canonical `home.account.gov.uk` URL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Unreleased
+
+- Modify Digital Identity URI to `home.account.gov.uk` ([#43](https://github.com/alphagov/govuk_personalisation/pull/43))
+
 # 0.12.0
 
 - Set account home to Digital Identity URI ([#36](https://github.com/alphagov/govuk_personalisation/pull/36))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,6 @@
 - Set account home to Digital Identity URI ([#36](https://github.com/alphagov/govuk_personalisation/pull/36))
 - Add `GovukPersonalisation::Urls.manage_email` link ([#38](https://github.com/alphagov/govuk_personalisation/pull/38))
 
-
 # 0.11.2
 
 - Add support for Rails 7 ([#33](https://github.com/alphagov/govuk_personalisation/pull/33))
@@ -25,10 +24,12 @@
 - Make session-change events uncacheable ([#24](https://github.com/alphagov/govuk_personalisation/pull/24))
 
 # 0.10.0
+
 - Add `url_with_analytics` helper to allow apps to access the URL used for `redirect_with_analytics` ([#22](https://github.com/alphagov/govuk_personalisation/pull/22))
 
 # 0.9.0
-- Add `redirect_with_analytics` helper, attaches _ga and cookie_consent values from existing params to redirects. ([#19](https://github.com/alphagov/govuk_personalisation/pull/19))
+
+- Add `redirect_with_analytics` helper, attaches \_ga and cookie_consent values from existing params to redirects. ([#19](https://github.com/alphagov/govuk_personalisation/pull/19))
 - Add `GovukPersonalisation::Redirect` and `.build_url` helper to construct valid URLs with additional parameters. ([#19](https://github.com/alphagov/govuk_personalisation/pull/19))
 
 # 0.8.0

--- a/lib/govuk_personalisation/urls.rb
+++ b/lib/govuk_personalisation/urls.rb
@@ -97,9 +97,9 @@ module GovukPersonalisation::Urls
   def self.digital_identity_domain
     environment = ENV["DIGITAL_IDENTITY_ENVIRONMENT"]
     if environment
-      "#{environment}.account.gov.uk"
+      "home.#{environment}.account.gov.uk"
     else
-      "account.gov.uk"
+      "home.account.gov.uk"
     end
   end
 end


### PR DESCRIPTION
GOV.UK One Login (Formerly Digital Identity) have decided to move the URL of their account management dashboard. It has moved from off their programme subdomain of account.gov.uk, to an application specifical `home.account.gov.uk` domain.

Redirects are in place between the two domains, so there is no interruption to traffic, however we should point users to a canonical domain when possible.

This update makes that happen