### PR TITLE
Dependabot to monitor GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,7 @@ updates:
     directory: /
     schedule:
       interval: daily
+  - package-ecosystem: "github-actions"
+    directory: /
+    schedule:
+      interval: daily


### PR DESCRIPTION
Trello: https://trello.com/c/QrxjshEm/270-move-ruby-gems-from-jenkins-to-github-actions

This will open PRs when the actions used are updated.