### PR TITLE
Use GOVUK_ENVIRONMENT as a backstop for DIGITAL_IDENTITY_ENVIRONMENT

### DIFF
--- a/lib/govuk_personalisation/urls.rb
+++ b/lib/govuk_personalisation/urls.rb
@@ -95,11 +95,16 @@ module GovukPersonalisation::Urls
   #
   # @return [String] the domain
   def self.digital_identity_domain
-    environment = ENV["DIGITAL_IDENTITY_ENVIRONMENT"]
-    if environment
-      "home.#{environment}.account.gov.uk"
+    if digital_identity_environment
+      "home.#{digital_identity_environment}.account.gov.uk"
     else
       "home.account.gov.uk"
     end
+  end
+
+  def self.digital_identity_environment
+    return ENV["DIGITAL_IDENTITY_ENVIRONMENT"] if ENV["DIGITAL_IDENTITY_ENVIRONMENT"]
+
+    ENV["GOVUK_ENVIRONMENT"] == "production" ? nil : ENV["GOVUK_ENVIRONMENT"]
   end
 end

--- a/spec/govuk_personalisation/urls_spec.rb
+++ b/spec/govuk_personalisation/urls_spec.rb
@@ -61,4 +61,48 @@ RSpec.describe GovukPersonalisation::Urls do
       end
     end
   end
+
+  describe "#digital_identity_domain" do
+    subject(:url) { described_class.digital_identity_domain }
+
+    it "returns the domain hostname" do
+      expect(url).to eq("home.account.gov.uk")
+    end
+
+    context "when the DIGITAL_IDENTITY_ENVIRONMENT env var is set" do
+      around do |example|
+        ClimateControl.modify("DIGITAL_IDENTITY_ENVIRONMENT" => "production") do
+          example.run
+        end
+      end
+
+      it "constructs the hostname from the env var" do
+        expect(url).to eq("home.production.account.gov.uk")
+      end
+    end
+
+    context "when the GOVUK_ENVIRONMENT env var is set to production" do
+      around do |example|
+        ClimateControl.modify("GOVUK_ENVIRONMENT" => "production") do
+          example.run
+        end
+      end
+
+      it "returns the domain hostname" do
+        expect(url).to eq("home.account.gov.uk")
+      end
+    end
+
+    context "when the GOVUK_ENVIRONMENT env var is not set to production" do
+      around do |example|
+        ClimateControl.modify("GOVUK_ENVIRONMENT" => "test") do
+          example.run
+        end
+      end
+
+      it "constructs the hostname from the env var" do
+        expect(url).to eq("home.test.account.gov.uk")
+      end
+    end
+  end
 end


### PR DESCRIPTION
- If DIGITAL_IDENTITY_ENVIRONMENT is missing, use GOVUK_ENVIRONMENT
- Unless it's set to "production", in which case ignore.

(We aren't currently setting DIGITAL_IDENTITY_ENVIRONMENT to anything, and the DI environments integration and staging match ours, so we should use GOVUK_ENVIRONMENT as a fallback to avoid setting DIGITAL_IDENTITY_ENVIRONMENT unless we have a specific need).

https://trello.com/c/SiAQ3dZU/2086-redirect-govuk-account-to-homeaccountgovuk