### PR TITLE
Release version 0.14.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
-# Unreleased
+# 0.14.0
 
-* Drop support for Ruby 2.7.
+- Use GOVUK_ENVIRONMENT as a backstop for DIGITAL_IDENTITY_ENVIRONMENT ([#53](https://github.com/alphagov/govuk_personalisation/pull/53))
+- Drop Ruby 2.7 support ([#51](https://github.com/alphagov/govuk_personalisation/pull/51))
 
 # 0.13.0
 

--- a/lib/govuk_personalisation/version.rb
+++ b/lib/govuk_personalisation/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module GovukPersonalisation
-  VERSION = "0.13.0"
+  VERSION = "0.14.0"
 end


### PR DESCRIPTION
- Use GOVUK_ENVIRONMENT as a backstop for DIGITAL_IDENTITY_ENVIRONMENT ([#53](https://github.com/alphagov/govuk_personalisation/pull/53))
- Drop Ruby 2.7 support ([#51](https://github.com/alphagov/govuk_personalisation/pull/51))

https://trello.com/c/SiAQ3dZU/2086-redirect-govuk-account-to-homeaccountgovuk

