### PR TITLE
Update URLs and method names for One Login

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Unreleased
+
+- Update URLs and method names for One Login ([#56](https://github.com/alphagov/govuk_personalisation/pull/56))
+
 # 0.14.0
 
 - Use GOVUK_ENVIRONMENT as a backstop for DIGITAL_IDENTITY_ENVIRONMENT ([#53](https://github.com/alphagov/govuk_personalisation/pull/53))

--- a/lib/govuk_personalisation/urls.rb
+++ b/lib/govuk_personalisation/urls.rb
@@ -22,32 +22,25 @@ module GovukPersonalisation::Urls
     find_govuk_url(var: "SIGN_OUT", application: "email-alert-frontend", path: "/email/manage")
   end
 
-  # Find the external URL for the "your account" page
+  # Find the external URL for the "your services" page on One Login
   #
   # @return [String] the URL
-  def self.your_account
-    find_external_url(var: "YOUR_ACCOUNT", url: "https://#{digital_identity_domain}")
+  def self.one_login_your_services
+    find_external_url(var: "ONE_LOGIN_YOUR_SERVICES", url: "https://#{digital_identity_domain('home')}")
   end
 
-  # Find the external URL for the "manage" page
+  # Find the external URL for the "security" page on One Login
   #
   # @return [String] the URL
-  def self.manage
-    find_external_url(var: "MANAGE", url: "https://#{digital_identity_domain}?link=manage-account")
+  def self.one_login_security
+    find_external_url(var: "ONE_LOGIN_SECURITY", url: "https://#{digital_identity_domain('home')}/security")
   end
 
-  # Find the external URL for the "security" page
+  # Find the external URL for the "feedback" page on One Login
   #
   # @return [String] the URL
-  def self.security
-    find_external_url(var: "SECURITY", url: "https://#{digital_identity_domain}?link=security-privacy")
-  end
-
-  # Find the external URL for the "feedback" page
-  #
-  # @return [String] the URL
-  def self.feedback
-    find_external_url(var: "FEEDBACK", url: "https://signin.account.gov.uk/support")
+  def self.one_login_feedback
+    find_external_url(var: "ONE_LOGIN_FEEDBACK", url: "https://#{digital_identity_domain('signin')}/support?supportType=PUBLIC")
   end
 
   # Finds a URL on www.gov.uk.  This method is used so we can have
@@ -91,14 +84,11 @@ module GovukPersonalisation::Urls
     ENV.fetch("GOVUK_PERSONALISATION_#{var}_URI", url)
   end
 
-  # Gets the Digital Identity domain for the current environment
-  #
-  # @return [String] the domain
-  def self.digital_identity_domain
+  def self.digital_identity_domain(host)
     if digital_identity_environment
-      "home.#{digital_identity_environment}.account.gov.uk"
+      "#{host}.#{digital_identity_environment}.account.gov.uk"
     else
-      "home.account.gov.uk"
+      "#{host}.account.gov.uk"
     end
   end
 

--- a/lib/govuk_personalisation/urls.rb
+++ b/lib/govuk_personalisation/urls.rb
@@ -29,6 +29,10 @@ module GovukPersonalisation::Urls
     find_external_url(var: "ONE_LOGIN_YOUR_SERVICES", url: "https://#{digital_identity_domain('home')}")
   end
 
+  def self.your_account
+    one_login_your_services
+  end
+
   # Find the external URL for the "security" page on One Login
   #
   # @return [String] the URL
@@ -36,11 +40,23 @@ module GovukPersonalisation::Urls
     find_external_url(var: "ONE_LOGIN_SECURITY", url: "https://#{digital_identity_domain('home')}/security")
   end
 
+  def self.manage
+    one_login_security
+  end
+
+  def self.security
+    one_login_security
+  end
+
   # Find the external URL for the "feedback" page on One Login
   #
   # @return [String] the URL
   def self.one_login_feedback
     find_external_url(var: "ONE_LOGIN_FEEDBACK", url: "https://#{digital_identity_domain('signin')}/support?supportType=PUBLIC")
+  end
+
+  def self.feedback
+    one_login_feedback
   end
 
   # Finds a URL on www.gov.uk.  This method is used so we can have

--- a/spec/govuk_personalisation/urls_spec.rb
+++ b/spec/govuk_personalisation/urls_spec.rb
@@ -63,7 +63,7 @@ RSpec.describe GovukPersonalisation::Urls do
   end
 
   describe "#digital_identity_domain" do
-    subject(:url) { described_class.digital_identity_domain }
+    subject(:url) { described_class.digital_identity_domain("home") }
 
     it "returns the domain hostname" do
       expect(url).to eq("home.account.gov.uk")


### PR DESCRIPTION
Updates the URLs for One Login URLs to match those available in One Login Home

Also:
- renames the methods to be more descriptive of actual use.
- adds aliases to the old names for the methods to ease transition (these can be removed when no longer needed)
