### PR TITLE
Release version 0.15.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
-# Unreleased
+# 0.15.0
 
 - Update URLs and method names for One Login ([#56](https://github.com/alphagov/govuk_personalisation/pull/56))
+- Note that this release deprecates the your_account, manage, security, and feedback methods of GovukPersonalisation::Urls, but retains them as aliases to allow easier transition. They will be removed in a later release.
 
 # 0.14.0
 

--- a/lib/govuk_personalisation/version.rb
+++ b/lib/govuk_personalisation/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module GovukPersonalisation
-  VERSION = "0.14.0"
+  VERSION = "0.15.0"
 end


### PR DESCRIPTION
- Update URLs and method names for One Login ([#56](https://github.com/alphagov/govuk_personalisation/pull/56))
- Note that this release deprecates the `your_account`, `manage`, `security`, and `feedback` methods of `GovukPersonalisation::Urls`, but retains them as aliases to allow easier transition. They will be removed in a later release.