### PR TITLE
Map our environments correctly to DI/One Login's environments.

### DIFF
--- a/lib/govuk_personalisation/urls.rb
+++ b/lib/govuk_personalisation/urls.rb
@@ -101,16 +101,24 @@ module GovukPersonalisation::Urls
   end
 
   def self.digital_identity_domain(host)
-    if digital_identity_environment
-      "#{host}.#{digital_identity_environment}.account.gov.uk"
-    else
+    if ["production", nil].include?(digital_identity_environment)
       "#{host}.account.gov.uk"
+    else
+      "#{host}.#{digital_identity_environment}.account.gov.uk"
     end
   end
+
+  # DI/One Login's environments don't map exactly to ours - their staging points to
+  # our integration and vice versa. So translate here.
+  DIGITAL_IDENTITY_ENVIRONMENT_MAP = {
+    "production" => "production",
+    "staging" => "integration",
+    "integration" => "staging",
+  }.freeze
 
   def self.digital_identity_environment
     return ENV["DIGITAL_IDENTITY_ENVIRONMENT"] if ENV["DIGITAL_IDENTITY_ENVIRONMENT"]
 
-    ENV["GOVUK_ENVIRONMENT"] == "production" ? nil : ENV["GOVUK_ENVIRONMENT"]
+    DIGITAL_IDENTITY_ENVIRONMENT_MAP[ENV["GOVUK_ENVIRONMENT"]] || ENV["GOVUK_ENVIRONMENT"]
   end
 end

--- a/spec/govuk_personalisation/urls_spec.rb
+++ b/spec/govuk_personalisation/urls_spec.rb
@@ -71,13 +71,13 @@ RSpec.describe GovukPersonalisation::Urls do
 
     context "when the DIGITAL_IDENTITY_ENVIRONMENT env var is set" do
       around do |example|
-        ClimateControl.modify("DIGITAL_IDENTITY_ENVIRONMENT" => "production") do
+        ClimateControl.modify("DIGITAL_IDENTITY_ENVIRONMENT" => "load-test") do
           example.run
         end
       end
 
       it "constructs the hostname from the env var" do
-        expect(url).to eq("home.production.account.gov.uk")
+        expect(url).to eq("home.load-test.account.gov.uk")
       end
     end
 
@@ -93,7 +93,7 @@ RSpec.describe GovukPersonalisation::Urls do
       end
     end
 
-    context "when the GOVUK_ENVIRONMENT env var is not set to production" do
+    context "when the GOVUK_ENVIRONMENT env var is set to an arbitrary value" do
       around do |example|
         ClimateControl.modify("GOVUK_ENVIRONMENT" => "test") do
           example.run
@@ -102,6 +102,34 @@ RSpec.describe GovukPersonalisation::Urls do
 
       it "constructs the hostname from the env var" do
         expect(url).to eq("home.test.account.gov.uk")
+      end
+    end
+
+    # NOTE: staging and integration in One Login are inverted compared
+    # to GOV.UK (our staging has to point to their integration and
+    # vice versa). Don't try to "fix" the following two tests unless
+    # something has explicitly changed!
+    context "when the GOVUK_ENVIRONMENT env var is set to staging" do
+      around do |example|
+        ClimateControl.modify("GOVUK_ENVIRONMENT" => "staging") do
+          example.run
+        end
+      end
+
+      it "returns the domain hostname with integration" do
+        expect(url).to eq("home.integration.account.gov.uk")
+      end
+    end
+
+    context "when the GOVUK_ENVIRONMENT env var is set to integration" do
+      around do |example|
+        ClimateControl.modify("GOVUK_ENVIRONMENT" => "integration") do
+          example.run
+        end
+      end
+
+      it "returns the domain hostname with staging" do
+        expect(url).to eq("home.staging.account.gov.uk")
       end
     end
   end


### PR DESCRIPTION
Their staging points to our integration and vice versa, so unless we do this mapping non-prod environments will end up with confusing user journeys.

https://gds.slack.com/archives/C012GEZBZM0/p1705490220168099