### PR TITLE
Release version 0.16.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 0.16.0
+
+- Update minimum required Ruby version ([#67](https://github.com/alphagov/govuk_personalisation/pull/67))
+- Map our environments correctly to DI/One Login's environments. ([#63](https://github.com/alphagov/govuk_personalisation/pull/63))
+
 # 0.15.0
 
 - Update URLs and method names for One Login ([#56](https://github.com/alphagov/govuk_personalisation/pull/56))

--- a/lib/govuk_personalisation/version.rb
+++ b/lib/govuk_personalisation/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module GovukPersonalisation
-  VERSION = "0.15.0"
+  VERSION = "0.16.0"
 end


### PR DESCRIPTION

- Update minimum required Ruby version ([#67](https://github.com/alphagov/govuk_personalisation/pull/67))
- Map our environments correctly to DI/One Login's environments. ([#63](https://github.com/alphagov/govuk_personalisation/pull/63))