### PR TITLE
Use V2 of GOV.UK Dependabot Merger

### DIFF
--- a/.govuk_dependabot_merger.yml
+++ b/.govuk_dependabot_merger.yml
@@ -1,6 +1,7 @@
-api_version: 1
-auto_merge:
+api_version: 2
+defaults:
+  auto_merge: false
+  update_external_dependencies: false # TODO: enable after verifying that this repo meets the conditions
+overrides:
   - dependency: rubocop-govuk
-    allowed_semver_bumps:
-      - patch
-      - minor
+    auto_merge: true


### PR DESCRIPTION
GOV.UK Dependency Merger configuration changed to allow automatic patching of all dependencies as described in RFC-167 [^1]. Consequently V1 no longer works. This updates the configuration to use the version 2 convention to reinstate the basic functionality of automatic patching of internal dependencies only. The default allowed_semver_bumps are [patch, minor].

Follow up work will be required to enable automatic patching of external dependencies, which we encourage the team to do.

[^1]: https://github.com/alphagov/govuk-rfcs/blob/main/rfc-167-auto-patch-dependencies.md