### PR TITLE
Release 1.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 1.0.0
+
+- Release 1 (no code changes, so this is not breaking in practise). Gem has been in use
+  for long enough that we should not keep marking it as a 0.x version.
+
 # 0.16.0
 
 - Update minimum required Ruby version ([#67](https://github.com/alphagov/govuk_personalisation/pull/67))

--- a/lib/govuk_personalisation/version.rb
+++ b/lib/govuk_personalisation/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module GovukPersonalisation
-  VERSION = "0.16.0"
+  VERSION = "1.0.0"
 end


### PR DESCRIPTION
Release 1 

There are no substantive changes since 0.16.0 (only for dependabot merges and code tidying), so this is not breaking in practise. The gem has been in use for long enough that we should not keep marking it as a 0.x version.