### PR TITLE
Release 1.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 1.1.0
+
+- Update Rails requirements to allow Rails 8 ([#85](https://github.com/alphagov/govuk_personalisation/pull/85))
+
 # 1.0.0
 
 - Release 1 (no code changes, so this is not breaking in practise). Gem has been in use

--- a/lib/govuk_personalisation/version.rb
+++ b/lib/govuk_personalisation/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module GovukPersonalisation
-  VERSION = "1.0.0"
+  VERSION = "1.1.0"
 end


### PR DESCRIPTION
- Update Rails requirements to allow Rails 8 ([#85](https://github.com/alphagov/govuk_personalisation/pull/85))