### PR TITLE
[PNP-9784] Notify Slack if Github Actions fail on 'main' 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,7 @@
 on: [push, pull_request]
 
+name: CI
+
 jobs:
   codeql-sast:
     name: CodeQL SAST scan

--- a/.github/workflows/notify-slack-on-failure.yml
+++ b/.github/workflows/notify-slack-on-failure.yml
@@ -1,0 +1,24 @@
+name: Notify Slack of failure on main
+
+on:
+  workflow_run:
+    workflows: [CI]
+    types: [completed]
+    branches: [main]
+
+jobs:
+  on-success:
+    runs-on: ubuntu-latest
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    steps:
+      - run: echo 'The triggering workflow passed'
+  on-failure:
+    runs-on: ubuntu-latest
+    if: ${{ github.event.workflow_run.conclusion == 'failure' }}
+    steps:
+      - name: Notify Slack if failure on main
+        uses: alphagov/govuk-infrastructure/.github/actions/report-run-failure@main
+        with:
+          slack_webhook_url: ${{ secrets.GOVUK_SLACK_WEBHOOK_URL }}
+          channel: govuk-patterns-and-pages-tech
+          message: "Github was unable to complete the CI Actions workflow - requires further investigation."


### PR DESCRIPTION
This will notify us if the CI workflow fails
and the new version of this gem was unable to
be created.

Platform Engineering have built a workflow to notify
us of this when a job fails - see https://github.com/alphagov/govuk-infrastructure/tree/main/.github/actions/report-run-failure
This needs to be run when the CI and deploy workflows
have finished - see https://docs.github.com/en/actions/reference/workflows-and-actions/events-that-trigger-workflows#running-a-workflow-based-on-the-conclusion-of-another-workflow